### PR TITLE
Add FA 5 prefixes to hexo extended tags

### DIFF
--- a/fontawesome.js
+++ b/fontawesome.js
@@ -1,3 +1,19 @@
 hexo.extend.tag.register('fa', function(args) {
     return '<i class="fa ' + args.map(function(arg) { return 'fa-' + arg; }).join(' ') + '"></i>';
 });
+
+hexo.extend.tag.register('fas', function(args) {
+    return '<i class="fas ' + args.map(function(arg) { return 'fa-' + arg; }).join(' ') + '"></i>';
+});
+
+hexo.extend.tag.register('fab', function(args) {
+    return '<i class="fab ' + args.map(function(arg) { return 'fa-' + arg; }).join(' ') + '"></i>';
+});
+
+hexo.extend.tag.register('far', function(args) {
+    return '<i class="far ' + args.map(function(arg) { return 'fa-' + arg; }).join(' ') + '"></i>';
+});
+
+hexo.extend.tag.register('fal', function(args) {
+    return '<i class="fal ' + args.map(function(arg) { return 'fa-' + arg; }).join(' ') + '"></i>';
+});


### PR DESCRIPTION
https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4

> Version 4 just had one prefix — fa. Version 5 has four prefixes to let us set the style of any icon easily:
...
fab, fas or fa, far, fal